### PR TITLE
Ninja generator on Windows via scikit-build instead of cibuildwheel env only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ cmake.version = 'CMakeLists.txt'
 ninja.version = '>=1.11'
 wheel.packages = []
 
+[[tool.scikit-build.overrides]]
+if.platform-system = 'win32'
+cmake.args = ['-G', 'Ninja']
+
 [tool.scikit-build.metadata.version]
 provider = 'crysfml_version'
 provider-path = 'tools'
@@ -73,9 +77,6 @@ repair-wheel-command = 'delocate-wheel --require-archs {delocate_archs} -w {dest
 archs = ['AMD64']
 before-build = 'pip install delvewheel'
 repair-wheel-command = 'delvewheel repair -w {dest_dir} {wheel}'
-
-[tool.cibuildwheel.windows.environment]
-CMAKE_GENERATOR = 'Ninja'
 
 [tool.versioningit.format]
 distance = '{base_version}+dev{distance}'


### PR DESCRIPTION
This should force non cibuildwheel to correctly pick up Ninja while building on windows, and cibuildwheel will also inherit it so shouldn't be an issue.

Tested this out with https://github.com/conda-forge/staged-recipes/pull/33228/